### PR TITLE
Ship dylib for x84-64-macosx

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,8 @@
 #lang info
 (define collection "readline-gpl")
 (define deps '("base"
-               "rackunit-lib"))
+               "rackunit-lib"
+               ("readline-gpl-x86-64-macosx" #:platform "x86_64-macosx")))
 (define pkg-desc "Readline GPL")
 (define version "1.0")
 (define pkg-authors '(leif))

--- a/private/readline-lib.rkt
+++ b/private/readline-lib.rkt
@@ -3,4 +3,4 @@
 (require ffi/unsafe)
 (provide readline-library)
 
-(define readline-library (ffi-lib "libreadline" '("5" "6" "4" "")))
+(define readline-library (ffi-lib "libreadline" '("8.0" "5" "6" "4" "")))


### PR DESCRIPTION
On MacOS, `libreadline.dylib` is symlinked to `libedit`:

```
$ cd /usr/lib
$ ls -l libreadline.dylib
lrwxr-xr-x  1 root  wheel  15 Oct 15  2019 libreadline.dylib -> libedit.3.dylib
```

Therefore, we need to also ship `libreadline` to make sure that it will take precedent over the fake one.

See the repo that hosts the dylib file at https://github.com/sorawee/readline-gpl-libs