### PR TITLE
look for libreadline versions 7 and 8

### DIFF
--- a/private/readline-lib.rkt
+++ b/private/readline-lib.rkt
@@ -3,4 +3,4 @@
 (require ffi/unsafe)
 (provide readline-library)
 
-(define readline-library (ffi-lib "libreadline" '("5" "6" "4" "")))
+(define readline-library (ffi-lib "libreadline" '("8" "7" "6" "5" "4" #f)))


### PR DESCRIPTION
The current version of libreadline is 8.1,
though some systems are still distributing only 7.0
(and OpenIndiana is still on 6.3 as of October 2020).

Also, try more recent versions before older supported
versions, and use `#f` rather than the equivalent,
but less prominently documented, `""`.